### PR TITLE
Remove unnecessary hooks section

### DIFF
--- a/wecheck-java/wedeploy.json
+++ b/wecheck-java/wedeploy.json
@@ -1,6 +1,3 @@
 {
-	"hooks": {
-		"build": "gradle -Dorg.gradle.native=false clean build -x test"
-	},
 	"id": "api"
 }


### PR DESCRIPTION
Hooks are not needed, as a Java recipe generates the proper image for Gradle-based projects, which compiles the project under the hood